### PR TITLE
1.2.8: Implement team-based access control (RBAC)

### DIFF
--- a/api/internal/handlers/rbac.go
+++ b/api/internal/handlers/rbac.go
@@ -1,0 +1,406 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"wws/api/internal/db"
+)
+
+const (
+	RoleAdmin  = "admin"
+	RoleMember = "member"
+	RoleViewer = "viewer"
+	RoleOwner  = "owner"
+)
+
+var validRoles = map[string]bool{
+	RoleAdmin:  true,
+	RoleMember: true,
+	RoleViewer: true,
+	RoleOwner:  true,
+}
+
+type RoleAssignment struct {
+	ID             int       `json:"id"`
+	UserID         int       `json:"user_id"`
+	OrganizationID int       `json:"organization_id"`
+	Role           string    `json:"role"`
+	AssignedBy     int       `json:"assigned_by"`
+	AssignedAt     time.Time `json:"assigned_at"`
+}
+
+type AssignRoleRequest struct {
+	UserID         int    `json:"user_id"`
+	OrganizationID int    `json:"organization_id"`
+	Role           string `json:"role"`
+}
+
+type MemberDetail struct {
+	ID             int       `json:"id"`
+	UserID         int       `json:"user_id"`
+	Username       string    `json:"username"`
+	Email          string    `json:"email"`
+	OrganizationID int       `json:"organization_id"`
+	Role           string    `json:"role"`
+	InvitedBy      int       `json:"invited_by,omitempty"`
+	Accepted       bool      `json:"accepted"`
+	CreatedAt      time.Time `json:"created_at"`
+}
+
+type ListMembersRequest struct {
+	OrganizationID int `json:"organization_id" form:"organization_id"`
+}
+
+func isValidRole(role string) bool {
+	return validRoles[role]
+}
+
+func assignRole(ctx context.Context, userID, orgID, assignedBy int, role string) error {
+	if !isValidRole(role) {
+		return fmt.Errorf("invalid role: %s", role)
+	}
+
+	result, err := db.DB.ExecContext(ctx,
+		`INSERT INTO members (user_id, organization_id, role, invited_by, accepted, created_at)
+		 VALUES (?, ?, ?, ?, 1, ?)
+		 ON CONFLICT(user_id, organization_id) DO UPDATE SET role = ?`,
+		userID, orgID, role, assignedBy, time.Now(), role,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to assign role: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("no rows affected")
+	}
+
+	return nil
+}
+
+func getUserByID(ctx context.Context, userID int) (*User, error) {
+	var user User
+	err := db.DB.QueryRowContext(ctx,
+		`SELECT id, github_id, username, email, created_at FROM users WHERE id = ?`,
+		userID,
+	).Scan(&user.ID, &user.GitHubID, &user.Username, &user.Email, &user.CreatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("user not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch user: %w", err)
+	}
+
+	return &user, nil
+}
+
+func listMembersByOrganization(ctx context.Context, orgID int) ([]MemberDetail, error) {
+	rows, err := db.DB.QueryContext(ctx,
+		`SELECT m.id, m.user_id, m.organization_id, m.role, m.invited_by, m.accepted, m.created_at,
+			 u.username, u.email
+		 FROM members m
+		 JOIN users u ON m.user_id = u.id
+		 WHERE m.organization_id = ?
+		 ORDER BY m.created_at ASC`,
+		orgID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list members: %w", err)
+	}
+	defer rows.Close()
+
+	var members []MemberDetail
+	for rows.Next() {
+		var member MemberDetail
+		var invitedBy sql.NullInt64
+		var acceptedInt int
+
+		err := rows.Scan(
+			&member.ID, &member.UserID, &member.OrganizationID, &member.Role,
+			&invitedBy, &acceptedInt, &member.CreatedAt,
+			&member.Username, &member.Email,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan member: %w", err)
+		}
+
+		if invitedBy.Valid {
+			member.InvitedBy = int(invitedBy.Int64)
+		}
+		member.Accepted = acceptedInt == 1
+
+		members = append(members, member)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating members: %w", err)
+	}
+
+	return members, nil
+}
+
+func canModifyRole(requesterID, targetUserID, orgID int, requesterRole, targetRole string) bool {
+	if requesterID == targetUserID {
+		return requesterRole == RoleOwner
+	}
+
+	roleHierarchy := map[string]int{
+		RoleViewer: 1,
+		RoleMember: 2,
+		RoleAdmin:  3,
+		RoleOwner:  4,
+	}
+
+	return roleHierarchy[requesterRole] > roleHierarchy[targetRole]
+}
+
+func AssignRoleHandler(w http.ResponseWriter, r *http.Request) error {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	var req AssignRoleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return fmt.Errorf("invalid request body: %w", err)
+	}
+
+	if req.UserID == 0 {
+		return fmt.Errorf("user_id is required")
+	}
+
+	if req.OrganizationID == 0 {
+		return fmt.Errorf("organization_id is required")
+	}
+
+	if req.Role == "" {
+		return fmt.Errorf("role is required")
+	}
+
+	if !isValidRole(req.Role) {
+		return fmt.Errorf("invalid role. Valid roles are: admin, member, viewer")
+	}
+
+	requesterID, err := requireAuth(r)
+	if err != nil {
+		return fmt.Errorf("authentication required: %w", err)
+	}
+
+	_, err = getOrganizationByID(ctx, req.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("organization not found: %w", err)
+	}
+
+	requesterMember, err := getMemberByUserAndOrg(ctx, requesterID, req.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("failed to get requester membership: %w", err)
+	}
+
+	if requesterMember == nil {
+		return fmt.Errorf("you are not a member of this organization")
+	}
+
+	if requesterMember.Role != RoleOwner && requesterMember.Role != RoleAdmin {
+		return fmt.Errorf("only admins and owners can assign roles")
+	}
+
+	targetMember, err := getMemberByUserAndOrg(ctx, req.UserID, req.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("failed to get target member: %w", err)
+	}
+
+	if targetMember == nil {
+		return fmt.Errorf("user is not a member of this organization")
+	}
+
+	if requesterMember.Role != RoleOwner {
+		if !canModifyRole(requesterID, req.UserID, req.OrganizationID, requesterMember.Role, targetMember.Role) {
+			return fmt.Errorf("you cannot modify the role of users with equal or higher privileges")
+		}
+	}
+
+	if err := assignRole(ctx, req.UserID, req.OrganizationID, requesterID, req.Role); err != nil {
+		return fmt.Errorf("failed to assign role: %w", err)
+	}
+
+	updatedMember, _ := getMemberByUserAndOrg(ctx, req.UserID, req.OrganizationID)
+
+	WriteJSON(w, http.StatusOK, updatedMember)
+
+	log.Printf("User %d assigned role '%s' to user %d in organization %d",
+		requesterID, req.Role, req.UserID, req.OrganizationID)
+
+	return nil
+}
+
+func ListMembersHandler(w http.ResponseWriter, r *http.Request) error {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	orgIDStr := r.URL.Query().Get("organization_id")
+	if orgIDStr == "" {
+		return fmt.Errorf("organization_id query parameter is required")
+	}
+
+	var orgID int
+	fmt.Sscanf(orgIDStr, "%d", &orgID)
+	if orgID == 0 {
+		return fmt.Errorf("invalid organization_id")
+	}
+
+	_, err := requireAuth(r)
+	if err != nil {
+		return fmt.Errorf("authentication required: %w", err)
+	}
+
+	org, err := getOrganizationByID(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("organization not found: %w", err)
+	}
+
+	members, err := listMembersByOrganization(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("failed to list members: %w", err)
+	}
+
+	WriteJSON(w, http.StatusOK, map[string]interface{}{
+		"organization_id":   orgID,
+		"organization_name": org.Name,
+		"members":           members,
+		"total":             len(members),
+	})
+
+	log.Printf("Listed %d members for organization %d", len(members), orgID)
+
+	return nil
+}
+
+func GetMemberHandler(w http.ResponseWriter, r *http.Request) error {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	userIDStr := r.URL.Query().Get("user_id")
+	orgIDStr := r.URL.Query().Get("organization_id")
+
+	if userIDStr == "" || orgIDStr == "" {
+		return fmt.Errorf("user_id and organization_id query parameters are required")
+	}
+
+	var userID, orgID int
+	fmt.Sscanf(userIDStr, "%d", &userID)
+	fmt.Sscanf(orgIDStr, "%d", &orgID)
+
+	if userID == 0 || orgID == 0 {
+		return fmt.Errorf("invalid user_id or organization_id")
+	}
+
+	_, err := requireAuth(r)
+	if err != nil {
+		return fmt.Errorf("authentication required: %w", err)
+	}
+
+	member, err := getMemberByUserAndOrg(ctx, userID, orgID)
+	if err != nil {
+		return fmt.Errorf("failed to get member: %w", err)
+	}
+
+	if member == nil {
+		return fmt.Errorf("member not found")
+	}
+
+	WriteJSON(w, http.StatusOK, member)
+
+	log.Printf("Retrieved member %d in organization %d", userID, orgID)
+
+	return nil
+}
+
+func RemoveMemberHandler(w http.ResponseWriter, r *http.Request) error {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	userIDStr := r.URL.Query().Get("user_id")
+	orgIDStr := r.URL.Query().Get("organization_id")
+
+	if userIDStr == "" || orgIDStr == "" {
+		return fmt.Errorf("user_id and organization_id query parameters are required")
+	}
+
+	var userID, orgID int
+	fmt.Sscanf(userIDStr, "%d", &userID)
+	fmt.Sscanf(orgIDStr, "%d", &orgID)
+
+	if userID == 0 || orgID == 0 {
+		return fmt.Errorf("invalid user_id or organization_id")
+	}
+
+	requesterID, err := requireAuth(r)
+	if err != nil {
+		return fmt.Errorf("authentication required: %w", err)
+	}
+
+	if userID == requesterID {
+		return fmt.Errorf("you cannot remove yourself from the organization")
+	}
+
+	orgCheck, err := getOrganizationByID(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("organization not found: %w", err)
+	}
+
+	if orgCheck.OwnerID == userID {
+		return fmt.Errorf("you cannot remove the organization owner")
+	}
+
+	requesterMember, err := getMemberByUserAndOrg(ctx, requesterID, orgID)
+	if err != nil {
+		return fmt.Errorf("failed to get requester membership: %w", err)
+	}
+
+	if requesterMember == nil {
+		return fmt.Errorf("you are not a member of this organization")
+	}
+
+	if requesterMember.Role != RoleOwner && requesterMember.Role != RoleAdmin {
+		return fmt.Errorf("only admins and owners can remove members")
+	}
+
+	targetMember, err := getMemberByUserAndOrg(ctx, userID, orgID)
+	if err != nil {
+		return fmt.Errorf("failed to get target member: %w", err)
+	}
+
+	if targetMember == nil {
+		return fmt.Errorf("member not found")
+	}
+
+	if requesterMember.Role != RoleOwner && targetMember.Role == RoleAdmin {
+		return fmt.Errorf("only owners can remove admins")
+	}
+
+	_, err = db.DB.ExecContext(ctx,
+		`DELETE FROM members WHERE user_id = ? AND organization_id = ?`,
+		userID, orgID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to remove member: %w", err)
+	}
+
+	log.Printf("User %d removed user %d from organization %d",
+		requesterID, userID, orgID)
+
+	WriteJSON(w, http.StatusOK, map[string]string{
+		"message": "Member removed successfully",
+	})
+
+	return nil
+}

--- a/api/internal/handlers/rbac_test.go
+++ b/api/internal/handlers/rbac_test.go
@@ -1,0 +1,695 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"wws/api/internal/crypto"
+	"wws/api/internal/db"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func createRBACTablesForTest(testDB *sql.DB) {
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			github_id TEXT UNIQUE NOT NULL,
+			username TEXT NOT NULL,
+			email TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE TABLE IF NOT EXISTS organizations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			owner_id INTEGER NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (owner_id) REFERENCES users(id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS members (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id INTEGER NOT NULL,
+			organization_id INTEGER NOT NULL,
+			role TEXT NOT NULL DEFAULT 'member',
+			invited_by INTEGER,
+			accepted INTEGER DEFAULT 0,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (user_id) REFERENCES users(id),
+			FOREIGN KEY (organization_id) REFERENCES organizations(id),
+			FOREIGN KEY (invited_by) REFERENCES users(id),
+			UNIQUE(user_id, organization_id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS sessions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id INTEGER NOT NULL,
+			token TEXT UNIQUE NOT NULL,
+			expires_at DATETIME NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+		)`,
+	}
+
+	for _, stmt := range statements {
+		_, err := testDB.Exec(stmt)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func setupRBACTestDB(t *testing.T) (*sql.DB, int, int, int) {
+	testDB, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("Failed to open test DB: %v", err)
+	}
+
+	createRBACTablesForTest(testDB)
+
+	db.DB = testDB
+
+	os.Setenv("WWS_ENCRYPTION_KEY", "test-encryption-key-for-rbac-tests")
+	crypto.InitEncryption()
+
+	ctx := context.Background()
+
+	user1Result, _ := testDB.ExecContext(ctx,
+		"INSERT INTO users (github_id, username, email) VALUES (?, ?, ?)",
+		"123", "owner", "owner@example.com",
+	)
+	user1ID, _ := user1Result.LastInsertId()
+
+	user2Result, _ := testDB.ExecContext(ctx,
+		"INSERT INTO users (github_id, username, email) VALUES (?, ?, ?)",
+		"456", "admin", "admin@example.com",
+	)
+	user2ID, _ := user2Result.LastInsertId()
+
+	testDB.ExecContext(ctx,
+		"INSERT INTO users (github_id, username, email) VALUES (?, ?, ?)",
+		"789", "member", "member@example.com",
+	)
+
+	orgResult, _ := testDB.ExecContext(ctx,
+		"INSERT INTO organizations (name, owner_id) VALUES (?, ?)",
+		"Test Org", user1ID,
+	)
+	orgID, _ := orgResult.LastInsertId()
+
+	testDB.ExecContext(ctx,
+		`INSERT INTO members (user_id, organization_id, role, invited_by, accepted, created_at)
+		 VALUES (?, ?, 'owner', ?, 1, ?)`,
+		user1ID, orgID, user1ID, time.Now(),
+	)
+
+	testDB.ExecContext(ctx,
+		`INSERT INTO members (user_id, organization_id, role, invited_by, accepted, created_at)
+		 VALUES (?, ?, 'admin', ?, 1, ?)`,
+		user2ID, orgID, user1ID, time.Now(),
+	)
+
+	sessionToken := "test-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		user1ID, sessionToken, expiresAt,
+	)
+
+	return testDB, int(user1ID), int(user2ID), int(orgID)
+}
+
+func TestIsValidRole(t *testing.T) {
+	validRoles := []string{"admin", "member", "viewer", "owner"}
+	for _, role := range validRoles {
+		if !isValidRole(role) {
+			t.Errorf("Expected '%s' to be a valid role", role)
+		}
+	}
+
+	invalidRoles := []string{"superadmin", "guest", "moderator", ""}
+	for _, role := range invalidRoles {
+		if isValidRole(role) {
+			t.Errorf("Expected '%s' to be an invalid role", role)
+		}
+	}
+}
+
+func TestAssignRole(t *testing.T) {
+	testDB, userID, _, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	ctx := context.Background()
+
+	err := assignRole(ctx, userID, orgID, userID, RoleViewer)
+	if err != nil {
+		t.Fatalf("Failed to assign role: %v", err)
+	}
+
+	member, err := getMemberByUserAndOrg(ctx, userID, orgID)
+	if err != nil {
+		t.Fatalf("Failed to get member: %v", err)
+	}
+
+	if member.Role != RoleViewer {
+		t.Errorf("Expected role '%s', got '%s'", RoleViewer, member.Role)
+	}
+}
+
+func TestAssignRoleInvalidRole(t *testing.T) {
+	testDB, userID, _, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	ctx := context.Background()
+
+	err := assignRole(ctx, userID, orgID, userID, "invalid_role")
+	if err == nil {
+		t.Error("Expected error for invalid role")
+	}
+}
+
+func TestGetMemberByUserAndOrg(t *testing.T) {
+	testDB, userID, _, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	ctx := context.Background()
+
+	member, err := getMemberByUserAndOrg(ctx, userID, orgID)
+	if err != nil {
+		t.Fatalf("Failed to get member: %v", err)
+	}
+
+	if member.UserID != userID {
+		t.Errorf("Expected user_id %d, got %d", userID, member.UserID)
+	}
+
+	if member.Role != RoleOwner {
+		t.Errorf("Expected role '%s', got '%s'", RoleOwner, member.Role)
+	}
+}
+
+func TestGetMemberByUserAndOrgNotFound(t *testing.T) {
+	testDB, _, _, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	ctx := context.Background()
+
+	member, err := getMemberByUserAndOrg(ctx, 9999, orgID)
+	if err != nil {
+		t.Fatalf("Failed to get member: %v", err)
+	}
+
+	if member != nil {
+		t.Error("Expected nil member for nonexistent user")
+	}
+}
+
+func TestListMembersByOrganization(t *testing.T) {
+	testDB, _, _, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	ctx := context.Background()
+
+	members, err := listMembersByOrganization(ctx, orgID)
+	if err != nil {
+		t.Fatalf("Failed to list members: %v", err)
+	}
+
+	if len(members) != 2 {
+		t.Errorf("Expected 2 members, got %d", len(members))
+	}
+}
+
+func TestCanModifyRole(t *testing.T) {
+	tests := []struct {
+		name           string
+		requesterRole  string
+		targetRole     string
+		requesterID    int
+		targetUserID   int
+		expectedResult bool
+	}{
+		{"Owner can modify self", RoleOwner, RoleViewer, 1, 1, true},
+		{"Owner can modify admin", RoleOwner, RoleAdmin, 1, 2, true},
+		{"Owner can modify member", RoleOwner, RoleMember, 1, 3, true},
+		{"Admin can modify member", RoleAdmin, RoleMember, 2, 3, true},
+		{"Admin can modify viewer", RoleAdmin, RoleViewer, 2, 3, true},
+		{"Admin cannot modify admin", RoleAdmin, RoleAdmin, 2, 3, false},
+		{"Admin cannot modify owner", RoleAdmin, RoleOwner, 2, 1, false},
+		{"Member cannot modify member", RoleMember, RoleMember, 3, 4, false},
+		{"Member cannot modify admin", RoleMember, RoleAdmin, 3, 2, false},
+		{"Viewer cannot modify member", RoleViewer, RoleMember, 4, 3, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := canModifyRole(tt.requesterID, tt.targetUserID, 1, tt.requesterRole, tt.targetRole)
+			if result != tt.expectedResult {
+				t.Errorf("Expected %v, got %v", tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestAssignRoleHandler(t *testing.T) {
+	testDB, _, adminID, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	SetOAuthDB(testDB)
+
+	ctx := context.Background()
+
+	memberResult, _ := testDB.ExecContext(ctx,
+		"INSERT INTO users (github_id, username, email) VALUES (?, ?, ?)",
+		"101", "newmember", "newmember@example.com",
+	)
+	memberID, _ := memberResult.LastInsertId()
+
+	testDB.ExecContext(ctx,
+		`INSERT INTO members (user_id, organization_id, role, invited_by, accepted, created_at)
+		 VALUES (?, ?, 'member', ?, 1, ?)`,
+		memberID, orgID, 1, time.Now(),
+	)
+
+	adminSessionToken := "admin-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		adminID, adminSessionToken, expiresAt,
+	)
+
+	reqBody := map[string]interface{}{
+		"user_id":         memberID,
+		"organization_id": orgID,
+		"role":            RoleAdmin,
+	}
+	jsonBody, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations/roles", bytes.NewBuffer(jsonBody))
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: adminSessionToken})
+	w := httptest.NewRecorder()
+
+	err := AssignRoleHandler(w, req)
+	if err != nil {
+		t.Fatalf("AssignRoleHandler returned error: %v", err)
+	}
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	var response map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	if response["role"] != RoleAdmin {
+		t.Errorf("Expected role '%s', got '%s'", RoleAdmin, response["role"])
+	}
+}
+
+func TestAssignRoleHandlerMissingFields(t *testing.T) {
+	testDB, _, adminID, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	SetOAuthDB(testDB)
+
+	adminSessionToken := "admin-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	ctx := context.Background()
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		adminID, adminSessionToken, expiresAt,
+	)
+
+	reqBody := map[string]interface{}{
+		"user_id":         1,
+		"organization_id": orgID,
+	}
+	jsonBody, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations/roles", bytes.NewBuffer(jsonBody))
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: adminSessionToken})
+	w := httptest.NewRecorder()
+
+	err := AssignRoleHandler(w, req)
+	if err == nil {
+		t.Error("Expected error for missing role")
+	}
+
+	if err.Error() != "role is required" {
+		t.Errorf("Expected 'role is required' error, got '%s'", err.Error())
+	}
+}
+
+func TestAssignRoleHandlerInvalidRole(t *testing.T) {
+	testDB, _, adminID, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	SetOAuthDB(testDB)
+
+	adminSessionToken := "admin-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	ctx := context.Background()
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		adminID, adminSessionToken, expiresAt,
+	)
+
+	reqBody := map[string]interface{}{
+		"user_id":         1,
+		"organization_id": orgID,
+		"role":            "superadmin",
+	}
+	jsonBody, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations/roles", bytes.NewBuffer(jsonBody))
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: adminSessionToken})
+	w := httptest.NewRecorder()
+
+	err := AssignRoleHandler(w, req)
+	if err == nil {
+		t.Error("Expected error for invalid role")
+	}
+}
+
+func TestAssignRoleHandlerNotMember(t *testing.T) {
+	testDB, _, _, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	SetOAuthDB(testDB)
+
+	ctx := context.Background()
+
+	nonMemberResult, _ := testDB.ExecContext(ctx,
+		"INSERT INTO users (github_id, username, email) VALUES (?, ?, ?)",
+		"202", "nonmember", "nonmember@example.com",
+	)
+	nonMemberID, _ := nonMemberResult.LastInsertId()
+
+	nonMemberSessionToken := "nonmember-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		nonMemberID, nonMemberSessionToken, expiresAt,
+	)
+
+	reqBody := map[string]interface{}{
+		"user_id":         1,
+		"organization_id": orgID,
+		"role":            RoleAdmin,
+	}
+	jsonBody, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations/roles", bytes.NewBuffer(jsonBody))
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: nonMemberSessionToken})
+	w := httptest.NewRecorder()
+
+	err := AssignRoleHandler(w, req)
+	if err == nil {
+		t.Error("Expected error for non-member")
+	}
+
+	if err.Error() != "you are not a member of this organization" {
+		t.Errorf("Expected 'you are not a member of this organization' error, got '%s'", err.Error())
+	}
+}
+
+func TestAssignRoleHandlerCannotModifyHigherPrivilege(t *testing.T) {
+	testDB, _, adminID, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	SetOAuthDB(testDB)
+
+	ctx := context.Background()
+
+	adminSessionToken := "admin-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		adminID, adminSessionToken, expiresAt,
+	)
+
+	reqBody := map[string]interface{}{
+		"user_id":         1,
+		"organization_id": orgID,
+		"role":            RoleOwner,
+	}
+	jsonBody, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations/roles", bytes.NewBuffer(jsonBody))
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: adminSessionToken})
+	w := httptest.NewRecorder()
+
+	err := AssignRoleHandler(w, req)
+	if err == nil {
+		t.Error("Expected error for modifying higher privilege user")
+	}
+
+	if err.Error() != "you cannot modify the role of users with equal or higher privileges" {
+		t.Errorf("Expected privilege error, got '%s'", err.Error())
+	}
+}
+
+func TestListMembersHandler(t *testing.T) {
+	testDB, ownerID, _, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	SetOAuthDB(testDB)
+
+	ownerSessionToken := "owner-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	ctx := context.Background()
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		ownerID, ownerSessionToken, expiresAt,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/organizations/members?organization_id=%d", orgID), nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: ownerSessionToken})
+	w := httptest.NewRecorder()
+
+	err := ListMembersHandler(w, req)
+	if err != nil {
+		t.Fatalf("ListMembersHandler returned error: %v", err)
+	}
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	var response map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	members := response["members"].([]interface{})
+	if len(members) != 2 {
+		t.Errorf("Expected 2 members, got %d", len(members))
+	}
+}
+
+func TestListMembersHandlerMissingOrgID(t *testing.T) {
+	testDB, ownerID, _, _ := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	SetOAuthDB(testDB)
+
+	ownerSessionToken := "owner-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	ctx := context.Background()
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		ownerID, ownerSessionToken, expiresAt,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations/members", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: ownerSessionToken})
+	w := httptest.NewRecorder()
+
+	err := ListMembersHandler(w, req)
+	if err == nil {
+		t.Error("Expected error for missing organization_id")
+	}
+}
+
+func TestGetMemberHandler(t *testing.T) {
+	testDB, ownerID, _, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	SetOAuthDB(testDB)
+
+	ownerSessionToken := "owner-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	ctx := context.Background()
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		ownerID, ownerSessionToken, expiresAt,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/organizations/members?user_id=1&organization_id=%d", orgID), nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: ownerSessionToken})
+	w := httptest.NewRecorder()
+
+	err := GetMemberHandler(w, req)
+	if err != nil {
+		t.Fatalf("GetMemberHandler returned error: %v", err)
+	}
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestRemoveMemberHandler(t *testing.T) {
+	testDB, ownerID, _, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	SetOAuthDB(testDB)
+
+	ctx := context.Background()
+
+	memberResult, _ := testDB.ExecContext(ctx,
+		"INSERT INTO users (github_id, username, email) VALUES (?, ?, ?)",
+		"303", "tomove", "toremove@example.com",
+	)
+	memberID, _ := memberResult.LastInsertId()
+
+	testDB.ExecContext(ctx,
+		`INSERT INTO members (user_id, organization_id, role, invited_by, accepted, created_at)
+		 VALUES (?, ?, 'member', ?, 1, ?)`,
+		memberID, orgID, ownerID, time.Now(),
+	)
+
+	ownerSessionToken := "owner-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		ownerID, ownerSessionToken, expiresAt,
+	)
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/organizations/members?user_id=%d&organization_id=%d", memberID, orgID), nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: ownerSessionToken})
+	w := httptest.NewRecorder()
+
+	err := RemoveMemberHandler(w, req)
+	if err != nil {
+		t.Fatalf("RemoveMemberHandler returned error: %v", err)
+	}
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	var response map[string]string
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	if response["message"] != "Member removed successfully" {
+		t.Errorf("Expected success message, got '%s'", response["message"])
+	}
+
+	member, _ := getMemberByUserAndOrg(ctx, int(memberID), orgID)
+	if member != nil {
+		t.Error("Expected member to be removed")
+	}
+}
+
+func TestRemoveMemberHandlerCannotRemoveSelf(t *testing.T) {
+	testDB, ownerID, _, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	SetOAuthDB(testDB)
+
+	ownerSessionToken := "owner-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	ctx := context.Background()
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		ownerID, ownerSessionToken, expiresAt,
+	)
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/organizations/members?user_id=1&organization_id=%d", orgID), nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: ownerSessionToken})
+	w := httptest.NewRecorder()
+
+	err := RemoveMemberHandler(w, req)
+	if err == nil {
+		t.Error("Expected error for removing self")
+	}
+
+	if err.Error() != "you cannot remove yourself from the organization" {
+		t.Errorf("Expected self-removal error, got '%s'", err.Error())
+	}
+}
+
+func TestRemoveMemberHandlerCannotRemoveOwner(t *testing.T) {
+	testDB, _, adminID, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	SetOAuthDB(testDB)
+
+	adminSessionToken := "admin-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	ctx := context.Background()
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		adminID, adminSessionToken, expiresAt,
+	)
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/organizations/members?user_id=1&organization_id=%d", orgID), nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: adminSessionToken})
+	w := httptest.NewRecorder()
+
+	err := RemoveMemberHandler(w, req)
+	if err == nil {
+		t.Error("Expected error for removing owner")
+	}
+
+	if err.Error() != "you cannot remove the organization owner" {
+		t.Errorf("Expected owner-removal error, got '%s'", err.Error())
+	}
+}
+
+func TestRemoveMemberHandlerAdminCannotRemoveAdmin(t *testing.T) {
+	testDB, _, adminID, orgID := setupRBACTestDB(t)
+	defer testDB.Close()
+
+	SetOAuthDB(testDB)
+
+	ctx := context.Background()
+
+	anotherAdminResult, _ := testDB.ExecContext(ctx,
+		"INSERT INTO users (github_id, username, email) VALUES (?, ?, ?)",
+		"404", "anotheradmin", "anotheradmin@example.com",
+	)
+	anotherAdminID, _ := anotherAdminResult.LastInsertId()
+
+	testDB.ExecContext(ctx,
+		`INSERT INTO members (user_id, organization_id, role, invited_by, accepted, created_at)
+		 VALUES (?, ?, 'admin', ?, 1, ?)`,
+		anotherAdminID, orgID, 1, time.Now(),
+	)
+
+	adminSessionToken := "admin-session-token"
+	expiresAt := time.Now().Add(7 * 24 * time.Hour)
+	testDB.ExecContext(ctx,
+		"INSERT INTO sessions (user_id, token, expires_at) VALUES (?, ?, ?)",
+		adminID, adminSessionToken, expiresAt,
+	)
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/organizations/members?user_id=%d&organization_id=%d", anotherAdminID, orgID), nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: adminSessionToken})
+	w := httptest.NewRecorder()
+
+	err := RemoveMemberHandler(w, req)
+	if err == nil {
+		t.Error("Expected error for admin removing admin")
+	}
+
+	if err.Error() != "only owners can remove admins" {
+		t.Errorf("Expected admin-removal error, got '%s'", err.Error())
+	}
+}

--- a/api/internal/routes/routes.go
+++ b/api/internal/routes/routes.go
@@ -35,6 +35,18 @@ func SetupRoutes(r *mux.Router) {
 	orgs.HandleFunc("", handlers.Adapter(handlers.ListOrganizationsHandler)).Methods("GET")
 	orgs.HandleFunc("", handlers.Adapter(handlers.CreateOrganizationHandler)).Methods("POST")
 
+	// Organization member routes
+	orgs.HandleFunc("/members", handlers.Adapter(handlers.ListMembersHandler)).Methods("GET")
+	orgs.HandleFunc("/members", handlers.Adapter(handlers.GetMemberHandler)).Methods("GET")
+	orgs.HandleFunc("/members", handlers.Adapter(handlers.RemoveMemberHandler)).Methods("DELETE")
+
+	// Organization role routes
+	orgs.HandleFunc("/roles", handlers.Adapter(handlers.AssignRoleHandler)).Methods("POST")
+
+	// Invitation routes
+	orgs.HandleFunc("/invitations", handlers.Adapter(handlers.CreateInvitationHandler)).Methods("POST")
+	orgs.HandleFunc("/invitations/accept", handlers.Adapter(handlers.AcceptInvitationHandler)).Methods("POST")
+
 	// Workspace routes
 	workspaces := api.PathPrefix("/workspaces").Subrouter()
 	workspaces.HandleFunc("", handlers.Adapter(handlers.ListWorkspacesHandler)).Methods("GET")


### PR DESCRIPTION
## Summary
Implements Phase 1.2.8 - Team-based Access Control (RBAC) for the WWS project.

## Changes
- Added RBAC handlers with role management endpoints
- Implemented role hierarchy (owner > admin > member > viewer)
- Added 4 new API endpoints:
  - POST /api/v1/organizations/roles - Assign role to member
  - GET /api/v1/organizations/members - List all organization members
  - GET /api/v1/organizations/members?user_id=X&organization_id=Y - Get specific member
  - DELETE /api/v1/organizations/members?user_id=X&organization_id=Y - Remove member
- Added comprehensive unit tests (20+ tests)
- Updated routes.go with new endpoints

## Testing
All unit tests pass:
- Role validation tests
- Role assignment tests with privilege hierarchy
- Member listing and retrieval tests
- Member removal tests with permission checks

## Related
Closes issue for Phase 1.2.8